### PR TITLE
fix extra_config template

### DIFF
--- a/charts/clickhouse/templates/_helpers.tpl
+++ b/charts/clickhouse/templates/_helpers.tpl
@@ -193,7 +193,7 @@ Keeper Host
 {{/*
 Extra Config
 */}}
-{{- define "clickhouse.extra_config" -}}
+{{- define "clickhouse.extraConfig" -}}
   {{- if not (empty .Values.clickhouse.extraConfig) -}}
     {{ .Values.clickhouse.extraConfig }}
   {{- else -}}


### PR DESCRIPTION
In templates/chi.yaml, it calls include "clickhouse.extraConfig", but the actual defined template name is clickhouse.extra_config.

However, since camelCase is generally used for template names, I went ahead and fixed it in _helpers.tpl.

Error message:
> Failed to load target state: failed to generate manifest for source 1 of 1: rpc error: code = Unknown desc = failed to execute helm template command: failed to get command args to log: `helm template . --name-template devops-clickhouse --namespace monitoring --kube-version 1.32 <api versions removed> --include-crds` failed exit status 1: Error: template: clickhouse/charts/clickhouse/templates/chi.yaml:68:29: executing "clickhouse/charts/clickhouse/templates/chi.yaml" at <include "clickhouse.extraConfig" .>: error calling include: template: no template "clickhouse.extraConfig" associated with template "gotpl" Use --debug flag to render out invalid YAML